### PR TITLE
fix: use platform dependant build flags

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,7 +2,11 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.flag("-Wno-unused-parameter");
+    if cfg!(windows) {
+        c_config.flag("/wd4100");
+    } else {
+        c_config.flag("-Wno-unused-parameter");
+    }
     c_config.std("c11").include(src_dir);
 
     let parser_path = src_dir.join("parser.c");

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,7 +2,7 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    if cfg!(windows) {
+    if cfg!(target_env = "msvc") {
         c_config.flag("/wd4100");
     } else {
         c_config.flag("-Wno-unused-parameter");


### PR DESCRIPTION
Compiling on Windows fails currently because the flag `-Wno-unused-parameter` is only valid for gcc, not for MSVC.
This PR uses the `/wd4100` flag instead when compiling on Windows.