### PR TITLE
fix: widen version range of the tree-sitter dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">=0.21.0"
+tree-sitter = ">=0.20.0"
 
 [build-dependencies]
 cc = "1.0.92"


### PR DESCRIPTION
This grammar seems to be working with tree-sitter v0.20.0 (although I have only tested highlighting), so if there is no requirement for v0.21.0 we should try and keep compatibility as much as possible.