### PR TITLE
Add support for map value and extend list value

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -103,6 +103,7 @@ module.exports = grammar(CSS, {
         $.nesting_selector,
         $._concatenated_identifier,
         $.list_value,
+        $.map_value,
       )),
       $.variable,
     ),
@@ -218,6 +219,12 @@ module.exports = grammar(CSS, {
       seq('(', sep2(optional(','), $._value), ')'),
       seq('[', sep2(optional(','), $._value), ']'),
       prec(-1, sep2(optional(','), $._value)),
+    ),
+
+    map_value: $ => seq(
+      '(',
+      sep2(',', seq($._value, ':', $._value)),
+      ')',
     ),
 
     interpolation: $ => seq('#{', $._value, '}'),

--- a/grammar.js
+++ b/grammar.js
@@ -84,7 +84,6 @@ module.exports = grammar(CSS, {
       ),
       ':',
       $._value,
-      repeat(seq(optional(','), $._value)),
       optional($.important),
       ';',
     ),
@@ -215,10 +214,10 @@ module.exports = grammar(CSS, {
       $._value,
     )),
 
-    list_value: $ => seq(
-      '(',
-      sep2(',', $._value),
-      ')',
+    list_value: $ => choice(
+      seq('(', sep2(optional(','), $._value), ')'),
+      seq('[', sep2(optional(','), $._value), ']'),
+      prec(-1, sep2(optional(','), $._value)),
     ),
 
     interpolation: $ => seq('#{', $._value, '}'),


### PR DESCRIPTION
Brackets are optional for list values, and the bracket pair can be either `(` or `[`. List can also be whitespace-separated.

This PR also adds a new value type Map.

I think my **list_value** implementation is rather dull, so putting here for feedback first. Once settled, I'll run `tree-sitter generate` and update test cases.

Ref:
* https://sass-lang.com/documentation/values/maps/
* https://sass-lang.com/documentation/values/lists/